### PR TITLE
feat: add mongodb tweet storage and retrieval logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.7.2",
         "dotenv": "^16.4.5",
+        "mongodb": "^6.7.0",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18"
@@ -19,6 +20,14 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.7.tgz",
+      "integrity": "sha512-dCHW/oEX0KJ4NjDULBo3JiOaK5+6axtpBbS+ao2ZInoAL9/YRQLhXzSNAFz7hP4nzLkIqsfYAK/PDE3+XHny0Q==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@next/env": {
@@ -209,6 +218,19 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -222,6 +244,14 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.7.0.tgz",
+      "integrity": "sha512-w2IquM5mYzYZv6rs3uN2DZTOBe2a0zXLj53TGDqwF4l6Sz/XsISrisXOJihArF9+BZ6Cq/GjVht7Sjfmri7ytQ==",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/busboy": {
@@ -348,6 +378,11 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -365,6 +400,60 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.7.0.tgz",
+      "integrity": "sha512-TMKyHdtMcO0fYBNORiYdmM25ijsHs+Njs963r4Tro4OQZzqYigAzYQouwWRg4OIaiLRUEGUh/1UAcH5lxdSLIA==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -470,6 +559,14 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -509,6 +606,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -539,6 +644,17 @@
         }
       }
     },
+    "node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -562,6 +678,26 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.7.2",
     "dotenv": "^16.4.5",
+    "mongodb": "^6.7.0",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18"

--- a/src/pages/api/ask.ts
+++ b/src/pages/api/ask.ts
@@ -4,7 +4,7 @@ const openAiApiBaseUrl = "https://api.openai.com/v1/chat/completions";
 
 const createPromptWithTweets = (tweets) => {
   const tweetsText = tweets.map((tweet) => tweet.text).join("\n");
-  return `Here are some tweets from the user:\n\n${tweetsText}\n\nBased on these tweets, answer the following question:`;
+  return `Here are some tweets from the user:\n\n${tweetsText}\n\nBased on these tweets, answer the following question with a yes or no answer and a single sentence for an explanation - avoid mentioning the author of the tweets name:`;
 };
 
 export default async function handler(req, res) {

--- a/src/pages/api/tweets.ts
+++ b/src/pages/api/tweets.ts
@@ -1,12 +1,17 @@
 import axios from "axios";
+import { MongoClient } from "mongodb";
+
+/*
+* Twitter Operations
+*/
 
 const twitterApiBaseUrl = "https://api.twitter.com/2";
 const headers = {
   Authorization: `Bearer ${process.env.TWITTER_BEARER_TOKEN}`,
 };
 
-const fetchTweets = async (userId, nextToken = null) => {
-  const url = `${twitterApiBaseUrl}/users/${userId}/tweets`;
+const fetchTweetsFromTwitter = async (authorId: string, nextToken: string | null = null) => {
+  const url = `${twitterApiBaseUrl}/users/${authorId}/tweets`;
   const params = {
     max_results: 100,
     "tweet.fields": "created_at,author_id",
@@ -18,29 +23,82 @@ const fetchTweets = async (userId, nextToken = null) => {
   return response.data;
 };
 
+/*
+* MongoDB Operations
+*/
+
+const fetchTweetsFromMongoDB = async (authorId: string, db) => {
+  return db.collection('tweets').findOne({ authorId });
+};
+
+const saveTweetsToMongoDB = async (authorId: string, tweets, db) => {
+  return db.collection('tweets').updateOne(
+    { authorId },
+    { $set: { authorId, tweets, lastUpdated: new Date() } },
+    { upsert: true }
+  );
+};
+
+const transformTweets = (tweets) => {
+  return tweets.map(tweet => ({
+    text: tweet.text,
+    created_at: tweet.created_at
+  }));
+};
+
 export default async function handler(req, res) {
   const { username } = req.query;
+
+  // Connect to MongoDB
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db();
+
   try {
+    // Get the user ID from Twitter API
     const userResponse = await axios.get(
       `${twitterApiBaseUrl}/users/by/username/${username}`,
       { headers }
     );
-    const userId = userResponse.data.data.id;
+    const authorId = userResponse.data.data.id;
 
-    let allTweets = [];
-    let nextToken = null;
-    let count = 0;
+    // Check MongoDB for existing tweets
+    const cachedTweets = await fetchTweetsFromMongoDB(authorId, db);
 
-    do {
-      const response = await fetchTweets(userId, nextToken);
-      allTweets = allTweets.concat(response.data);
-      nextToken = response.meta.next_token;
-      count += response.data.length;
-    } while (nextToken && count < 1000); // Fetch up to 1000 tweets
+    if (cachedTweets) {
+      // Return cached tweets if they exist
+      res.status(200).json({
+        author_id: cachedTweets.authorId,
+        tweets: cachedTweets.tweets
+      });
+    } else {
+      // Fetch tweets from Twitter API
+      let allTweets = [];
+      let nextToken = null;
+      let count = 0;
 
-    res.status(200).json(allTweets);
+      do {
+        const response = await fetchTweetsFromTwitter(authorId, nextToken);
+        const filteredTweets = transformTweets(response.data);
+        allTweets = allTweets.concat(filteredTweets);
+        nextToken = response.meta.next_token;
+        count += response.data.length;
+      } while (nextToken && count < 1000); // Fetch up to 1000 tweets
+
+      // Save the new tweets to MongoDB
+      await saveTweetsToMongoDB(authorId, allTweets, db);
+
+      // Return the fetched tweets
+      res.status(200).json({
+        author_id: authorId,
+        tweets: allTweets
+      });
+    }
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: "Failed to fetch tweets" });
+  } finally {
+    // Close the MongoDB connection
+    await client.close();
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ export default function Home() {
     try {
       const response = await fetch(`/api/tweets?username=${username}`);
       const data = await response.json();
-      setTweets(data);
+      setTweets(data.tweets);
     } catch (error) {
       console.error("Error fetching tweets:", error);
     }


### PR DESCRIPTION
* the MongoDB URI is provided as an environment variable (`MONGODB_URI`) like with the `TWITTER_BEARER_TOKEN`
* tweet data is stored in MongoDB in the following format (example):
```
{
  "authorId": "973261472",
  "tweets": [
    {
      "text": "bro like this is insane lmao https://t.co/f5dm3QmLF5",
      "created_at": "2024-05-18T21:08:22.000Z"
    },
    {
      "text": "another tweet example text",
      "created_at": "2024-05-17T19:22:10.000Z"
    }
  ],
  "lastUpdated": "2024-05-29T00:00:00.000Z"  // current date and time
}
```
...and returned in the response payload as follows:
```
{
  "author_id": "973261472",
  "tweets": [
    {
      "text": "bro like this is insane lmao https://t.co/f5dm3QmLF5",
      "created_at": "2024-05-18T21:08:22.000Z"
    },
    {
      "text": "another tweet example text",
      "created_at": "2024-05-17T19:22:10.000Z"
    }
  ]
}
```